### PR TITLE
Allow stats to be filtered by host and/or tags

### DIFF
--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -15,7 +15,7 @@ import (
 )
 
 var cmdStats = &cobra.Command{
-	Use:   "stats [flags] [snapshot-ID]",
+	Use:   "stats [snapshotID] [flags]",
 	Short: "Scan the repository and show basic statistics",
 	Long: `
 The "stats" command walks one or all snapshots in a repository and
@@ -54,9 +54,9 @@ func init() {
 	cmdRoot.AddCommand(cmdStats)
 	f := cmdStats.Flags()
 	f.StringVar(&countMode, "mode", countModeRestoreSize, "counting mode: restore-size (default), files-by-contents, blobs-per-file, or raw-data")
-	f.StringArrayVarP(&snapshotByHosts, "host", "H", nil, "filter latest snapshot by this hostname (can be specified multiple times)")
-	f.Var(&snapshotByTags, "tag", "filter latest snapshot by this `taglist` (can be specified multiple times)")
-	f.StringArrayVar(&snapshotByPaths, "path", nil, "filter latest snapshot by this `path` (can be specified multiple times)")
+	f.StringArrayVarP(&snapshotByHosts, "host", "H", nil, "filter snapshots by this hostname (can be specified multiple times)")
+	f.Var(&snapshotByTags, "tag", "filter snapshots by this `taglist` (can be specified multiple times)")
+	f.StringArrayVar(&snapshotByPaths, "path", nil, "filter snapshots by this `path` (can be specified multiple times)")
 }
 
 func runStats(gopts GlobalOptions, args []string) error {

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -124,14 +124,10 @@ func runStats(gopts GlobalOptions, args []string) error {
 			return fmt.Errorf("error walking snapshot: %v", err)
 		}
 	} else {
-		// iterate every snapshot in the repo
-		err = repo.List(ctx, restic.SnapshotFile, func(snapshotID restic.ID, size int64) error {
-			snapshot, err := restic.LoadSnapshot(ctx, repo, snapshotID)
-			if err != nil {
-				return fmt.Errorf("Error loading snapshot %s: %v", snapshotID.Str(), err)
-			}
-			return statsWalkSnapshot(ctx, snapshot, repo, stats)
-		})
+		// iterate snapshots after filtered
+		for sn := range FindFilteredSnapshots(ctx, repo, snapshotByHosts, snapshotByTags, snapshotByPaths, args) {
+			statsWalkSnapshot(ctx, sn, repo, stats)
+		}
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Snapshots are filtered before iterated to calculate stats

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://forum.restic.net/t/stats-for-a-host-and-filtered-snapshots/3020

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
